### PR TITLE
fix(aria): correct 'labeledBy' → 'labelledBy' spelling in ARIA attribute

### DIFF
--- a/Sources/HTML/Attributes/Aria/AriaLabeledByAttributeModifier.swift
+++ b/Sources/HTML/Attributes/Aria/AriaLabeledByAttributeModifier.swift
@@ -13,11 +13,11 @@ public protocol AriaLabeledByAttributeModifier {
 
 extension AriaLabeledByAttributeModifier where Self: Attributes & Mutable {
 
-    public func ariaLabeledBy(
+    public func ariaLabelledBy(
         _ value: AriaLabeledByAttributeValueType?
     ) -> Self {
         setAttribute(
-            key: AriaAttributeKey.labeledBy,
+            key: AriaAttributeKey.labelledBy,
             value: value?.attributeValue
         )
     }

--- a/Sources/HTML/Attributes/AriaAttributeKeys.swift
+++ b/Sources/HTML/Attributes/AriaAttributeKeys.swift
@@ -28,7 +28,7 @@ enum AriaAttributeKey: String, AttributeKeyRepresentable {
     case invalid
     case keyShortcuts = "keyshortcuts"
     case label
-    case labeledBy = "labeledby"
+    case labelledBy = "labelledby"
     case level
     case live
     case modal

--- a/Tests/HTMLTests/Attributes/Aria/AriaLabeledByAttributeTestSuite.swift
+++ b/Tests/HTMLTests/Attributes/Aria/AriaLabeledByAttributeTestSuite.swift
@@ -15,13 +15,13 @@ struct AriaLabeledByAttributeTestSuite {
     @Test
     func rendersAriaLabeledByValue() async throws {
         let tag = A {}
-            .ariaLabeledBy("value")
+            .ariaLabelledBy("value")
 
         let renderer = Renderer()
         let doc = Document(root: tag)
 
         let expectation = #"""
-            <a aria-labeledby="value"></a>
+            <a aria-labelledby="value"></a>
             """#
 
         let result = renderer.render(document: doc)


### PR DESCRIPTION
## Summary
Fix the ARIA attribute spelling: `aria-labeledby` → `aria-labelledby` (British spelling with double-L).

### Changes (3 files, 5 lines)
1. **AriaAttributeKeys.swift**: `case labeledBy = "labeledby"` → `case labelledBy = "labelledby"`
2. **AriaLabeledByAttributeModifier.swift**: Method renamed `ariaLabeledBy` → `ariaLabelledBy`, key updated to `AriaAttributeKey.labelledBy`
3. **Test updated**: expectation now correctly expects `aria-labelledby` instead of `aria-labeledby`

### Why this fix
Per [MDN WAI-ARIA docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-labelledby), the correct attribute name is `aria-labelledby` with double-L (British spelling).

Fixes: issue #35